### PR TITLE
🚀 UPDATE: v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipfs-support-extension",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Adding standalone IPFS native URL support for chromium based browsers without installing IPFS in your machine.",
   "scripts": {
     "start": "parcel watch src/manifest.json --host localhost",

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
   "devDependencies": {
     "@parcel/config-webextension": "^2.8.2",
     "parcel": "^2.8.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,13 @@
     {
       "matches": [
         "https://google.com/search?q=ipfs%3A%2F%2F*",
-        "https://www.google.com/search?q=ipfs%3A%2F%2F*"
+        "https://www.google.com/search?q=ipfs%3A%2F%2F*",
+        "https://bing.com/search?q=ipfs%3A%2F%2F*",
+        "https://www.bing.com/search?q=ipfs%3A%2F%2F*",
+        "https://duckduckgo.com/?q=ipfs%3A%2F%2F*",
+        "https://www.duckduckgo.com/?q=ipfs%3A%2F%2*",
+        "https://search.brave.com/search?q=ipfs%3A%2F%2*",
+        "https://www.search.brave.com/search?q=ipfs%3A%2F%2*"
       ],
       "js": ["contentScript.js"]
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "IPFS Support",
   "description": "Adding standalone IPFS native URL support for chromium based browsers without installing IPFS in your machine.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Waren Gonzaga",
   "icons": {
     "16": "assets/icon16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,9 @@
         "https://duckduckgo.com/?q=ipfs%3A%2F%2F*",
         "https://www.duckduckgo.com/?q=ipfs%3A%2F%2*",
         "https://search.brave.com/search?q=ipfs%3A%2F%2*",
-        "https://www.search.brave.com/search?q=ipfs%3A%2F%2*"
+        "https://www.search.brave.com/search?q=ipfs%3A%2F%2*",
+        "https://search.yahoo.com/search?p=ipfs%3A%2F%2*",
+        "https://www.search.yahoo.com/search?p=ipfs%3A%2F%2*"
       ],
       "js": ["contentScript.js"]
     }

--- a/src/popup.html
+++ b/src/popup.html
@@ -45,7 +45,7 @@
     <div class="img-wrapper">
         <img src="assets/icon128.png" alt="Icon"/>
     </div>
-    <div class="title">IPFS Support <span class="version">v0.1.1</span></div>
+    <div class="title">IPFS Support <span class="version">v0.1.2</span></div>
     <p>By <a href="https://warengonzaga.com" target="_blank" rel="noopener">Waren Gonzaga</a></p>
     <p class="description">Adding standalone IPFS native URL support for chromium based browsers without installing IPFS in your machine. 📦🌐🧩</p>
     <div class="sponsor">

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,9 +817,9 @@ callsites@^3.0.0:
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001441"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz#987437b266260b640a23cd18fbddb509d7f69f3e"
-  integrity sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==
+  version "1.0.30001572"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz"
+  integrity sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==
 
 chalk@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
## Changes

- Add support to Edge search engine.
- Add support to DuckDuckGo search engine.
- Add support to Brave search engine.
- Add support to Yahoo search engine.

This is to ensure that no matter what search engine you are using, the extension can detect what you are trying to browse using your native IPFS link.